### PR TITLE
Lag service for mottak av meldeperioder fra behandlingsflyt

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/meldekort/behandlingsflytApi.kt
+++ b/app/src/main/kotlin/no/nav/aap/meldekort/behandlingsflytApi.kt
@@ -6,7 +6,7 @@ import com.papsign.ktor.openapigen.route.route
 import io.ktor.http.*
 import no.nav.aap.Ident
 import no.nav.aap.Periode
-import no.nav.aap.kelvin.KelvinSakRepository
+import no.nav.aap.kelvin.KelvinMottakService
 import no.nav.aap.kelvin.KelvinSakStatus
 import no.nav.aap.komponenter.config.configForKey
 import no.nav.aap.komponenter.dbconnect.transaction
@@ -28,21 +28,23 @@ fun NormalOpenAPIRoute.behandlingsflytApi(dataSource: DataSource, repositoryRegi
         auditLogConfig = null,
     ) { _, body ->
         dataSource.transaction { connection ->
-            repositoryRegistry.provider(connection).provide<KelvinSakRepository>()
-                .upsertSak(
-                    saksnummer = Fagsaknummer(body.saksnummer),
-                    identer = body.identer.map { Ident(it) },
-                    sakenGjelderFor = Periode(body.sakenGjelderFor.fom, body.sakenGjelderFor.tom),
-                    meldeperioder = body.meldeperioder.map { Periode(it.fom, it.tom) },
-                    opplysningsbehov = body.opplysningsbehov.map { Periode(it.fom, it.tom) },
-                    meldeplikt = body.meldeperioder.map { Periode(it.fom, it.tom) },
-                    status = when (body.sakStatus) {
-                        SakStatus.UTREDES -> KelvinSakStatus.UTREDES
-                        SakStatus.LØPENDE -> KelvinSakStatus.LØPENDE
-                        SakStatus.AVSLUTTET -> KelvinSakStatus.AVSLUTTET
-                        null -> null
-                    }
-                )
+            val repositoryProvider = repositoryRegistry.provider(connection)
+            val kelvinMottakService = KelvinMottakService(repositoryProvider)
+
+            kelvinMottakService.behandleMottatteMeldeperioder(
+                saksnummer = Fagsaknummer(body.saksnummer),
+                identer = body.identer.map { Ident(it) },
+                sakenGjelderFor = Periode(body.sakenGjelderFor.fom, body.sakenGjelderFor.tom),
+                meldeperioder = body.meldeperioder.map { Periode(it.fom, it.tom) },
+                opplysningsbehov = body.opplysningsbehov.map { Periode(it.fom, it.tom) },
+                meldeplikt = body.meldeperioder.map { Periode(it.fom, it.tom) },
+                status = when (body.sakStatus) {
+                    SakStatus.UTREDES -> KelvinSakStatus.UTREDES
+                    SakStatus.LØPENDE -> KelvinSakStatus.LØPENDE
+                    SakStatus.AVSLUTTET -> KelvinSakStatus.AVSLUTTET
+                    null -> null
+                }
+            )
         }
         respondWithStatus(HttpStatusCode.OK)
     }

--- a/app/src/test/kotlin/no/nav/aap/meldekort/TestApp.kt
+++ b/app/src/test/kotlin/no/nav/aap/meldekort/TestApp.kt
@@ -5,7 +5,7 @@ import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import no.nav.aap.Ident
 import no.nav.aap.Periode
 import no.nav.aap.behandlingsflyt.prometheus
-import no.nav.aap.kelvin.KelvinSakRepositoryPostgres
+import no.nav.aap.kelvin.KelvinMottakService
 import no.nav.aap.kelvin.KelvinSakStatus
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.azurecc.AzureConfig
@@ -19,6 +19,7 @@ import no.nav.aap.sak.Fagsaknummer
 import no.nav.aap.sak.FagsystemNavn.ARENA
 import no.nav.aap.sak.FagsystemNavn.KELVIN
 import java.time.Clock
+import java.time.DayOfWeek
 import java.time.LocalDate
 
 fun main() {
@@ -48,21 +49,30 @@ fun main() {
     val dataSource = createTestcontainerPostgresDataSource(prometheus)
 
     dataSource.transaction { connection ->
-        val kelvinSakRepository = KelvinSakRepositoryPostgres(connection)
-        kelvinSakRepository.upsertSak(
-            saksnummer = Fagsaknummer("111111"),
+        val repositoryProvider = postgresRepositoryRegistry.provider(connection)
+        val kelvinMottakService = KelvinMottakService(repositoryProvider)
+        val iDag = LocalDate.now()
+        val sistMandag = generateSequence(iDag) { it.minusDays(1) }
+            .first { it.dayOfWeek == DayOfWeek.MONDAY }
+
+        kelvinMottakService.behandleMottatteMeldeperioder(
+            saksnummer = Fagsaknummer("1015"),
             sakenGjelderFor = Periode(LocalDate.of(2020, 1, 1), LocalDate.of(2026, 1, 1)),
             identer = listOf(Ident("11111111111")),
             meldeperioder =
-                listOf(
-                    "2025-02-10" to "2025-02-23",
-                    "2025-02-24" to "2025-03-09",
-                    "2025-03-10" to "2025-03-23",
-                    "2025-03-24" to "2025-04-06",
-                ).map { (fom, tom) -> Periode(LocalDate.parse(fom), LocalDate.parse(tom)) },
-            meldeplikt = listOf(),
+                lagPerioder(
+                    sistMandag.minusDays(14) to sistMandag.minusDays(1),
+                    sistMandag to sistMandag.plusDays(13),
+                    sistMandag.plusDays(14) to sistMandag.plusDays(27),
+                ),
+            meldeplikt =
+                lagPerioder(
+                    sistMandag to sistMandag.plusDays(7),
+                    sistMandag.plusDays(14) to sistMandag.plusDays(21),
+                    sistMandag.plusDays(28) to sistMandag.plusDays(35),
+                ),
             opplysningsbehov = listOf(
-                Periode(LocalDate.of(2025, 2, 13), LocalDate.of(2025, 4, 8)),
+                Periode(LocalDate.of(2020, 1, 1), LocalDate.of(2026, 1, 1)),
             ),
             status = KelvinSakStatus.LØPENDE,
         )
@@ -80,4 +90,8 @@ fun main() {
         repositoryRegistry = postgresRepositoryRegistry,
         clock = Clock.systemDefaultZone(),
     )
+}
+
+private fun lagPerioder(vararg fomTom: Pair<LocalDate, LocalDate>): List<Periode> {
+    return fomTom.map { (fom, tom) -> Periode(fom, tom) }
 }

--- a/meldekortdomene/src/main/kotlin/no/nav/aap/kelvin/KelvinMottakService.kt
+++ b/meldekortdomene/src/main/kotlin/no/nav/aap/kelvin/KelvinMottakService.kt
@@ -1,0 +1,33 @@
+package no.nav.aap.kelvin
+
+import no.nav.aap.Ident
+import no.nav.aap.Periode
+import no.nav.aap.komponenter.repository.RepositoryProvider
+import no.nav.aap.sak.Fagsaknummer
+
+class KelvinMottakService(private val kelvinSakRepository: KelvinSakRepository) {
+
+    constructor(repositoryProvider: RepositoryProvider) : this(
+        kelvinSakRepository = repositoryProvider.provide(),
+    )
+
+    fun behandleMottatteMeldeperioder(
+        saksnummer: Fagsaknummer,
+        sakenGjelderFor: Periode,
+        identer: List<Ident>,
+        meldeperioder: List<Periode>,
+        meldeplikt: List<Periode>,
+        opplysningsbehov: List<Periode>,
+        status: KelvinSakStatus?
+    ) {
+        kelvinSakRepository.upsertSak(
+            saksnummer = saksnummer,
+            sakenGjelderFor = sakenGjelderFor,
+            identer = identer,
+            meldeperioder = meldeperioder,
+            meldeplikt = meldeplikt,
+            opplysningsbehov = opplysningsbehov,
+            status = status
+        )
+    }
+}


### PR DESCRIPTION
Introduserer service mellom API og repository for å kunne legge inn annen logikk ved mottak av meldeperioder fra behandlingsflyt. Endrer også oppsett i TestApp til å bruke en opprettet sak og perioder basert på dagens dato, gjennom den nye servicen.