### PR TITLE
Ikke close fake servers i tester

### DIFF
--- a/app/src/test/kotlin/no/nav/aap/meldekort/AnsvarligSystemIntegrasjonsTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/meldekort/AnsvarligSystemIntegrasjonsTest.kt
@@ -135,7 +135,6 @@ class AnsvarligSystemIntegrasjonsTest {
     companion object {
         private lateinit var embeddedServer: EmbeddedServer<*, *>
         lateinit var client: RestClient<InputStream>
-        private val fakeServers = FakeServers()
 
         val dataSource = createTestcontainerPostgresDataSource(prometheus)
 
@@ -156,7 +155,7 @@ class AnsvarligSystemIntegrasjonsTest {
         @JvmStatic
         @BeforeAll
         fun beforeAll() {
-            fakeServers.start()
+            FakeServers.start()
 
             setupRegistries()
 
@@ -185,7 +184,6 @@ class AnsvarligSystemIntegrasjonsTest {
         @AfterAll
         fun afterAll() {
             embeddedServer.stop(0L, 0L)
-            fakeServers.close()
         }
     }
 }

--- a/app/src/test/kotlin/no/nav/aap/meldekort/KelvinIntegrasjonsPåFastsattDagTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/meldekort/KelvinIntegrasjonsPåFastsattDagTest.kt
@@ -218,14 +218,11 @@ class KelvinIntegrasjonsPåFastsattDagTest {
             )
         }
 
-
-        private val fakeServers = FakeServers()
-
         @JvmStatic
         @BeforeAll
         fun beforeAll() {
             FakeTokenX.port = 0
-            fakeServers.start()
+            FakeServers.start()
 
             setupRegistries()
 
@@ -254,7 +251,6 @@ class KelvinIntegrasjonsPåFastsattDagTest {
         @AfterAll
         fun afterAll() {
             embeddedServer.stop(0L, 0L)
-            fakeServers.close()
         }
     }
 }

--- a/app/src/test/kotlin/no/nav/aap/meldekort/TestApp.kt
+++ b/app/src/test/kotlin/no/nav/aap/meldekort/TestApp.kt
@@ -23,7 +23,7 @@ import java.time.LocalDate
 
 fun main() {
     FakeTokenX.port = 8081
-    FakeServers().start()
+    FakeServers.start()
 
     setupRegistries()
 

--- a/lib-test/src/main/kotlin/no/nav/aap/meldekort/test/FakeServers.kt
+++ b/lib-test/src/main/kotlin/no/nav/aap/meldekort/test/FakeServers.kt
@@ -14,11 +14,15 @@ interface FakeServer {
     val port: Int get() = 0
 }
 
-class FakeServers : AutoCloseable {
+object FakeServers : AutoCloseable {
     private val logger = LoggerFactory.getLogger(this.javaClass)
 
     private val fakeServers = listOf(FakeTokenX, FakeAzure, FakeAapApi, FakeArena, FakeDokarkiv, FakePdfgen)
         .map { it to embeddedServer(Netty, port = it.port, module = it.module) }
+
+    init {
+        Runtime.getRuntime().addShutdownHook(Thread { close() })
+    }
 
     private val started = AtomicBoolean(false)
 


### PR DESCRIPTION
Når fake servers deles på tvers av tester kan de bli skrudd av før alle testene er ferdig. Legg heller inn en shutdown hook