### PR TITLE
Gjenbruk av Kafka producer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,4 +86,5 @@ dependencies {
     }
     testImplementation(kotlin("test"))
     testImplementation(project(":lib-test"))
+    testImplementation("org.testcontainers:kafka:1.21.2")
 }

--- a/app/src/main/kotlin/no/nav/aap/meldekort/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/meldekort/App.kt
@@ -11,7 +11,7 @@ import no.nav.aap.meldekort.journalføring.DokarkivGatewayImpl
 import no.nav.aap.meldekort.journalføring.PdfgenGatewayImpl
 import no.nav.aap.meldekort.saker.AapGatewayImpl
 import no.nav.aap.postgresRepositoryRegistry
-import no.nav.aap.varsel.VarselGatewayKafkaProducer
+import no.nav.aap.varsel.VarselGatewayKafkaProducerNais
 import org.slf4j.LoggerFactory
 import java.time.Clock
 
@@ -43,6 +43,6 @@ fun setupRegistries() {
         .register<AapGatewayImpl>()
         .register<ArenaGatewayImpl>()
         .register<PdfgenGatewayImpl>()
-        .register<VarselGatewayKafkaProducer>()
+        .register<VarselGatewayKafkaProducerNais>()
         .status()
 }

--- a/app/src/test/kotlin/no/nav/aap/meldekort/AnsvarligSystemIntegrasjonsTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/meldekort/AnsvarligSystemIntegrasjonsTest.kt
@@ -17,6 +17,9 @@ import no.nav.aap.komponenter.httpklient.httpclient.request.GetRequest
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.TokenProvider
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.azurecc.AzureConfig
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.tokenx.TokenxConfig
+import no.nav.aap.lookup.gateway.GatewayRegistry
+import no.nav.aap.meldekort.arena.ArenaGatewayImpl
+import no.nav.aap.meldekort.saker.AapGatewayImpl
 import no.nav.aap.meldekort.test.FakeAapApi
 import no.nav.aap.meldekort.test.FakeServers
 import no.nav.aap.meldekort.test.FakeTokenX
@@ -157,10 +160,11 @@ class AnsvarligSystemIntegrasjonsTest {
         fun beforeAll() {
             FakeServers.start()
 
-            setupRegistries()
+            GatewayRegistry
+                .register<AapGatewayImpl>()
+                .register<ArenaGatewayImpl>()
 
             embeddedServer = run {
-                setupRegistries()
                 startHttpServer(
                     port = 0,
                     prometheus = PrometheusMeterRegistry(PrometheusConfig.DEFAULT),

--- a/app/src/test/kotlin/no/nav/aap/meldekort/BehandlingsflytApiKtTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/meldekort/BehandlingsflytApiKtTest.kt
@@ -18,6 +18,7 @@ import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.azurecc.AzureC
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.azurecc.ClientCredentialsTokenProvider
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.tokenx.TokenxConfig
 import no.nav.aap.lookup.gateway.GatewayRegistry
+import no.nav.aap.meldekort.arena.ArenaGatewayImpl
 import no.nav.aap.meldekort.kontrakt.Periode
 import no.nav.aap.meldekort.kontrakt.sak.MeldeperioderV0
 import no.nav.aap.meldekort.test.FakeServers
@@ -110,8 +111,9 @@ import kotlin.test.*
          fun beforeAll() {
              FakeServers.start()
 
-             setupRegistries()
-             GatewayRegistry.register<FakeVarselGateway>()
+             GatewayRegistry
+                 .register<ArenaGatewayImpl>()
+                 .register<FakeVarselGateway>()
 
              embeddedServer =
                  startHttpServer(

--- a/app/src/test/kotlin/no/nav/aap/meldekort/KelvinIntegrasjonsPåFastsattDagTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/meldekort/KelvinIntegrasjonsPåFastsattDagTest.kt
@@ -4,10 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode
 import io.ktor.server.engine.EmbeddedServer
 import io.micrometer.prometheusmetrics.PrometheusConfig
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
-import java.io.InputStream
-import java.net.URI
-import java.time.LocalDate
-import kotlin.test.assertEquals
 import no.nav.aap.Ident
 import no.nav.aap.Periode
 import no.nav.aap.behandlingsflyt.prometheus
@@ -21,6 +17,9 @@ import no.nav.aap.komponenter.httpklient.httpclient.request.GetRequest
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.TokenProvider
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.azurecc.AzureConfig
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.tokenx.TokenxConfig
+import no.nav.aap.lookup.gateway.GatewayRegistry
+import no.nav.aap.meldekort.arena.ArenaGatewayImpl
+import no.nav.aap.meldekort.saker.AapGatewayImpl
 import no.nav.aap.meldekort.test.FakeAapApi
 import no.nav.aap.meldekort.test.FakeServers
 import no.nav.aap.meldekort.test.FakeTokenX
@@ -30,10 +29,13 @@ import no.nav.aap.sak.FagsakReferanse
 import no.nav.aap.sak.FagsystemNavn
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import java.io.InputStream
+import java.net.URI
 import java.time.Clock
+import java.time.LocalDate
 import java.time.ZoneId
+import kotlin.test.assertEquals
 
 /**
  * ```
@@ -224,10 +226,11 @@ class KelvinIntegrasjonsPåFastsattDagTest {
             FakeTokenX.port = 0
             FakeServers.start()
 
-            setupRegistries()
+            GatewayRegistry
+                .register<AapGatewayImpl>()
+                .register<ArenaGatewayImpl>()
 
             embeddedServer = run {
-                setupRegistries()
                 startHttpServer(
                     port = 0,
                     prometheus = PrometheusMeterRegistry(PrometheusConfig.DEFAULT),

--- a/lib-test/build.gradle.kts
+++ b/lib-test/build.gradle.kts
@@ -40,4 +40,5 @@ dependencies {
 
     implementation("org.junit.jupiter:junit-jupiter-api:$junitVersjon")
     implementation("org.testcontainers:postgresql:1.21.3")
+    implementation("no.nav.tms.varsel:kotlin-builder:2.1.1")
 }

--- a/lib-test/src/main/kotlin/no/nav/aap/meldekort/VarselGatewayKafkaProducerTestcontainers.kt
+++ b/lib-test/src/main/kotlin/no/nav/aap/meldekort/VarselGatewayKafkaProducerTestcontainers.kt
@@ -1,0 +1,17 @@
+package no.nav.aap.meldekort
+
+import no.nav.aap.KafkaProducerConfig
+import no.nav.aap.varsel.VarselGatewayKafkaProducer
+import no.nav.tms.varsel.builder.BuilderEnvironment
+
+object VarselGatewayKafkaProducerTestcontainers : VarselGatewayKafkaProducer(KafkaProducerConfig(sslConfig = null)) {
+    init {
+        BuilderEnvironment.extend(
+            mapOf(
+                "NAIS_CLUSTER_NAME" to "lokalt",
+                "NAIS_NAMESPACE" to "aap",
+                "NAIS_APP_NAME" to "meldekort-backend"
+            )
+        )
+    }
+}

--- a/repositories/src/test/kotlin/no/nav/aap/meldekort/varsel/VarselGatewayKafkaProducerTest.kt
+++ b/repositories/src/test/kotlin/no/nav/aap/meldekort/varsel/VarselGatewayKafkaProducerTest.kt
@@ -1,10 +1,9 @@
 package no.nav.aap.meldekort.varsel
 
-import no.nav.aap.KafkaProducerConfig
 import no.nav.aap.komponenter.json.DefaultJsonMapper
+import no.nav.aap.meldekort.VarselGatewayKafkaProducerTestcontainers
 import no.nav.aap.meldekort.fødselsnummerGenerator
 import no.nav.aap.varsel.TEKSTER_OPPGAVE_MELDEPLIKTPERIODE
-import no.nav.aap.varsel.VarselGatewayKafkaProducer
 import no.nav.tms.varsel.action.EksternKanal
 import no.nav.tms.varsel.action.OpprettVarsel
 import no.nav.tms.varsel.action.Produsent
@@ -56,13 +55,12 @@ class VarselGatewayKafkaProducerTest {
         )
         val topic = "brukervarsel-topic"
         System.setProperty("brukervarsel.topic", topic)
-        val producerConfig = KafkaProducerConfig(kafkaContainer.bootstrapServers, sslConfig = null)
-        val producer = VarselGatewayKafkaProducer(producerConfig)
+        System.setProperty("KAFKA_BROKERS", kafkaContainer.bootstrapServers)
 
         val brukerIdent = fødselsnummerGenerator.next()
         val varsel = byggVarsel()
 
-        producer.sendVarsel(brukerIdent, varsel, TEKSTER_OPPGAVE_MELDEPLIKTPERIODE, "https://www.nav.no/aap/meldekort")
+        VarselGatewayKafkaProducerTestcontainers.sendVarsel(brukerIdent, varsel, TEKSTER_OPPGAVE_MELDEPLIKTPERIODE, "https://www.nav.no/aap/meldekort")
 
         val consumer = KafkaConsumer<String, String>(kafkaTestConsumerProperties(kafkaContainer.bootstrapServers))
         consumer.subscribe(listOf(topic))


### PR DESCRIPTION
Gjenbruker Kafka producer for levetiden av applikasjonsinstansen og lukker produceren korrekt ved stopp av applikasjonsinstansen. Bruker også Kafka med testcontainers ved kjøring av TestApp lokalt.