### PR TITLE
Ta høyde for forsinkelse i utsendingsjobb for varsler

### DIFF
--- a/meldekortdomene/src/main/kotlin/no/nav/aap/varsel/VarselRepository.kt
+++ b/meldekortdomene/src/main/kotlin/no/nav/aap/varsel/VarselRepository.kt
@@ -7,6 +7,7 @@ import java.time.Clock
 interface VarselRepository: Repository {
     fun hentVarsler(saksnummer: Fagsaknummer): List<Varsel>
     fun upsert(varsel: Varsel)
+    fun slettVarsel(varselId: VarselId)
     fun slettPlanlagteVarsler(saksnummer: Fagsaknummer, typeVarselOm: TypeVarselOm)
     fun hentVarslerForUtsending(clock: Clock) : List<Varsel>
 }

--- a/repositories/src/main/kotlin/no/nav/aap/varsel/VarselRepositoryPostgres.kt
+++ b/repositories/src/main/kotlin/no/nav/aap/varsel/VarselRepositoryPostgres.kt
@@ -57,6 +57,22 @@ class VarselRepositoryPostgres(private val connection: DBConnection) : VarselRep
         }
     }
 
+    override fun slettVarsel(varselId: VarselId) {
+        connection.execute(
+            """
+            delete from varsel
+            where varsel_id = ?
+            """
+        ) {
+            setParams {
+                setUUID(1, varselId.id)
+            }
+            setResultValidator {
+                require(it == 1)
+            }
+        }
+    }
+
     override fun slettPlanlagteVarsler(
         saksnummer: Fagsaknummer,
         typeVarselOm: TypeVarselOm

--- a/repositories/src/test/kotlin/no/nav/aap/meldekort/varsel/VarselRepositoryPostgresTest.kt
+++ b/repositories/src/test/kotlin/no/nav/aap/meldekort/varsel/VarselRepositoryPostgresTest.kt
@@ -24,7 +24,7 @@ import java.time.Clock
 
 class VarselRepositoryPostgresTest {
     @Test
-    fun `oppretter, henter og oppdaterer varsler`() {
+    fun `oppretter, henter, oppdaterer og sletter varsler`() {
         val saksnummer = Fagsaknummer("123")
 
         InitTestDatabase.freshDatabase().transaction { connection ->
@@ -67,6 +67,12 @@ class VarselRepositoryPostgresTest {
 
             varselRepo.hentVarsler(saksnummer).also { varsler ->
                 assertThat(varsler).containsExactly(oppdatertVarsel)
+            }
+
+            varselRepo.slettVarsel(varsel.varselId)
+
+            varselRepo.hentVarsler(saksnummer).also { varsler ->
+                assertThat(varsler).isEmpty()
             }
         }
     }


### PR DESCRIPTION
Sletter planlagt varsel som skal sendes dersom det allerede finnes en utfylling for perioden det gjelder. Dersom dette oppstår tyder det på forsinkelse i utsendingsjobb.