### PR TITLE
Ikke planlegg varsel dersom forPeriode overlapper med en utfylling

### DIFF
--- a/meldekortdomene/src/main/kotlin/no/nav/aap/varsel/VarselService.kt
+++ b/meldekortdomene/src/main/kotlin/no/nav/aap/varsel/VarselService.kt
@@ -90,7 +90,7 @@ class VarselService(
     }
 
     private fun harUtfylling(forPeriode: Periode, utfyllinger: List<Utfylling>): Boolean {
-        return utfyllinger.map { it.periode }.contains(forPeriode)
+        return utfyllinger.any { it.periode.overlapper(forPeriode) }
     }
 
     private fun hentFerdigeUtfyllinger(saksnummer: Fagsaknummer): List<Utfylling> {


### PR DESCRIPTION
Perioden varselet gjelder for er begrenset til de dagene det er opplysningsbehov.