### PR TITLE
Fix/race conditions med kontrakt

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,7 +90,9 @@ jobs:
         permissions:
             contents: read
             id-token: write
-        needs: dev
+        needs:
+            - dev
+            - publiser-kontrakt
         uses: navikt/aap-workflows/.github/workflows/deploy.yml@main
         secrets: inherit
         with:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
 Fix for to race conditions hvor bare en av deploy av kontrakt og deploy av app virker. Deploy av kontrakt rulles ikke tilbake.

Endringen gjør at kontrakt sin publish må være grønn for at appen skal deployes i prod.

Case 1) Deploy av app til prod feiler, men kontrakten deployes. De som skal teste ut noe nytt som forutsetter at den nye kontrakten brukes aktivt kan oppleve feil og overraskelser, og miste tid på det.

Case 2) Deploy av app i prod OK, deploy av kontrakt feiler. Dersom bygg depender på LATEST fremfor en fixed version av kontrakten, og får den publisert uten at selve tjenesten kontrakten hører til er deployet i riktig versjon. I praksis gjør ingen bygg det nå, SVJV. Men jeg har lyst til å sette opp et sånt bygg, for å teste kompatibilitet til `kontrakter`. 