### PR TITLE
Bestill varsel på aktiv ident

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/meldekort/behandlingsflytApi.kt
+++ b/app/src/main/kotlin/no/nav/aap/meldekort/behandlingsflytApi.kt
@@ -99,7 +99,11 @@ fun NormalOpenAPIRoute.behandlingsflytApi(
 
                 kelvinMottakService.behandleOppdaterteIdenter(
                     saksnummer = Fagsaknummer(body.saksnummer),
-                    identer = body.identer.map { Ident(it) },
+                    identer = body.brukerIdenter?.map {
+                        Ident(asString = it.ident, aktiv = it.aktiv)
+                    } ?: body.identer.map {
+                        Ident(asString = it, aktiv = null)
+                    },
                 )
             }
             respondWithStatus(HttpStatusCode.OK)

--- a/app/src/main/kotlin/no/nav/aap/meldekort/behandlingsflytApi.kt
+++ b/app/src/main/kotlin/no/nav/aap/meldekort/behandlingsflytApi.kt
@@ -44,7 +44,7 @@ fun NormalOpenAPIRoute.behandlingsflytApi(
 
                 kelvinMottakService.behandleMottatteMeldeperioder(
                     saksnummer = Fagsaknummer(body.saksnummer),
-                    identer = body.brukerIdenter?.map {
+                    identer = body.personIdenter?.map {
                         Ident(asString = it.ident, aktiv = it.aktiv)
                     } ?: body.identer.map {
                         Ident(asString = it, aktiv = null)
@@ -99,7 +99,7 @@ fun NormalOpenAPIRoute.behandlingsflytApi(
 
                 kelvinMottakService.behandleOppdaterteIdenter(
                     saksnummer = Fagsaknummer(body.saksnummer),
-                    identer = body.brukerIdenter?.map {
+                    identer = body.personIdenter?.map {
                         Ident(asString = it.ident, aktiv = it.aktiv)
                     } ?: body.identer.map {
                         Ident(asString = it, aktiv = null)

--- a/app/src/main/kotlin/no/nav/aap/meldekort/behandlingsflytApi.kt
+++ b/app/src/main/kotlin/no/nav/aap/meldekort/behandlingsflytApi.kt
@@ -44,7 +44,11 @@ fun NormalOpenAPIRoute.behandlingsflytApi(
 
                 kelvinMottakService.behandleMottatteMeldeperioder(
                     saksnummer = Fagsaknummer(body.saksnummer),
-                    identer = body.identer.map { Ident(it) },
+                    identer = body.brukerIdenter?.map {
+                        Ident(asString = it.ident, aktiv = it.aktiv)
+                    } ?: body.identer.map {
+                        Ident(asString = it, aktiv = null)
+                    },
                     sakenGjelderFor = Periode(body.sakenGjelderFor.fom, body.sakenGjelderFor.tom),
                     meldeperioder = body.meldeperioder.map { Periode(it.fom, it.tom) },
                     opplysningsbehov = body.opplysningsbehov.map { Periode(it.fom, it.tom) },

--- a/kontrakt/src/main/kotlin/no/nav/aap/meldekort/kontrakt/sak/Sak.kt
+++ b/kontrakt/src/main/kotlin/no/nav/aap/meldekort/kontrakt/sak/Sak.kt
@@ -4,6 +4,7 @@ import no.nav.aap.meldekort.kontrakt.Periode
 import java.time.LocalDate
 
 public class MeldeperioderV0(
+    public val brukerIdenter: List<Ident>? = null, // Erstatter `identer`
     public val identer: List<String>,
     public val saksnummer: String,
     public val sakenGjelderFor: Periode,
@@ -17,6 +18,11 @@ public class MeldeperioderV0(
      * gir oss opplysninger gjennom meldekortet.
      */
     public val opplysningsbehov: List<Periode> = emptyList(),
+)
+
+public class Ident(
+    public val ident: String,
+    public val aktiv: Boolean? = null,
 )
 
 public enum class SakStatus {
@@ -41,5 +47,6 @@ public data class TimerArbeidetDto(
 
 public class OppdaterIdenterV0(
     public val saksnummer: String,
+    public val brukerIdenter: List<Ident>? = null, // Erstatter `identer`
     public val identer: List<String>,
 )

--- a/kontrakt/src/main/kotlin/no/nav/aap/meldekort/kontrakt/sak/Sak.kt
+++ b/kontrakt/src/main/kotlin/no/nav/aap/meldekort/kontrakt/sak/Sak.kt
@@ -4,7 +4,8 @@ import no.nav.aap.meldekort.kontrakt.Periode
 import java.time.LocalDate
 
 public class MeldeperioderV0(
-    public val brukerIdenter: List<Ident>? = null, // Erstatter `identer`
+    public val personIdenter: List<Ident>? = null,
+    @Deprecated("Erstattes av personIdenter", ReplaceWith("personIdenter"))
     public val identer: List<String>,
     public val saksnummer: String,
     public val sakenGjelderFor: Periode,
@@ -47,6 +48,7 @@ public data class TimerArbeidetDto(
 
 public class OppdaterIdenterV0(
     public val saksnummer: String,
-    public val brukerIdenter: List<Ident>? = null, // Erstatter `identer`
+    public val personIdenter: List<Ident>? = null,
+    @Deprecated("Erstattes av personIdenter", ReplaceWith("personIdenter"))
     public val identer: List<String>,
 )

--- a/meldekortdomene/src/main/kotlin/no/nav/aap/InnloggetBruker.kt
+++ b/meldekortdomene/src/main/kotlin/no/nav/aap/InnloggetBruker.kt
@@ -1,6 +1,9 @@
 package no.nav.aap
 
-data class Ident(val asString: String)
+data class Ident(
+    val asString: String,
+    val aktiv: Boolean? = true,
+)
 
 class InnloggetBruker(
     val ident: Ident,

--- a/meldekortdomene/src/main/kotlin/no/nav/aap/varsel/VarselService.kt
+++ b/meldekortdomene/src/main/kotlin/no/nav/aap/varsel/VarselService.kt
@@ -171,8 +171,9 @@ class VarselService(
             )
         )
 
-        // TODO hent gjeldende ident fra PDL
-        val brukerId = kelvinSakRepository.hentIdenter(varsel.saksnummer).first()
+        val brukerId = kelvinSakRepository.hentIdenter(varsel.saksnummer).let { identer ->
+            identer.firstOrNull { it.aktiv ?: false } ?: identer.first()
+        }
         val varselTekster = when (varsel.typeVarselOm) {
             TypeVarselOm.MELDEPLIKTPERIODE -> TEKSTER_OPPGAVE_MELDEPLIKTPERIODE
             else -> TODO("ikke implenetert støtte for varseltype ${varsel.typeVarselOm}")

--- a/meldekortdomene/src/test/kotlin/no/nav/aap/varsel/VarselServiceTest.kt
+++ b/meldekortdomene/src/test/kotlin/no/nav/aap/varsel/VarselServiceTest.kt
@@ -149,6 +149,54 @@ class VarselServiceTest {
     }
 
     @Test
+    fun `sender varsel på aktiv ident`() {
+        dataSource.transaction { connection ->
+            val varselRepository = VarselRepositoryPostgres(connection)
+
+            val saksnummer = saksnummerGenerator.next()
+            val ident1 = fødselsnummerGenerator.next().copy(aktiv = false)
+            val ident2 = fødselsnummerGenerator.next().copy(aktiv = true)
+            val ident3 = fødselsnummerGenerator.next().copy(aktiv = false)
+            val sakenGjelderFor = Periode(LocalDate.of(2025, 6, 30), LocalDate.of(2025, 6, 30).plusYears(1))
+            val opplysningsbehov = listOf(sakenGjelderFor)
+            val meldeperioder = lagPerioder(
+                LocalDate.of(2025, 7, 14) to LocalDate.of(2025, 7, 27),
+            )
+            val meldeplikt = lagPerioder(
+                LocalDate.of(2025, 7, 28) to LocalDate.of(2025, 8, 4),
+            )
+
+            kelvinMottakService(
+                connection,
+                clockMedTid(LocalDate.of(2025, 6, 30).atTime(1, 1))
+            ).behandleMottatteMeldeperioder(
+                saksnummer,
+                sakenGjelderFor,
+                listOf(ident1, ident2, ident3),
+                meldeperioder,
+                meldeplikt,
+                opplysningsbehov,
+                KelvinSakStatus.LØPENDE
+            )
+
+            varselService(connection, clockMedTid(LocalDateTime.of(2025, 7, 28, 9, 0)))
+                .sendPlanlagteVarsler()
+
+            assertVarsler(
+                varselRepository,
+                saksnummer,
+                ForventetVarsel(
+                    sendingstidspunkt = LocalDateTime.of(2025, 7, 28, 9, 0),
+                    forPeriode = Periode(LocalDate.of(2025, 7, 14), LocalDate.of(2025, 7, 27)),
+                    status = VarselStatus.SENDT
+                )
+            )
+
+            verify(exactly = 1) { varselGateway.sendVarsel(ident2, any(), any(), any()) }
+        }
+    }
+
+    @Test
     fun `sender varsel tidligere (17 desember) for meldeperioden i uke 50-51`() {
         dataSource.transaction { connection ->
             val varselRepository = VarselRepositoryPostgres(connection)

--- a/repositories/src/main/kotlin/no/nav/aap/kelvin/KelvinSakRepositoryPostgres.kt
+++ b/repositories/src/main/kotlin/no/nav/aap/kelvin/KelvinSakRepositoryPostgres.kt
@@ -181,16 +181,18 @@ class KelvinSakRepositoryPostgres(private val connection: DBConnection) : Kelvin
 
         connection.executeBatch(
             """
-            insert into kelvin_person_ident (person_id, ident)
-            values (?, ?)
+            insert into kelvin_person_ident (person_id, ident, aktiv)
+            values (?, ?, ?)
             on conflict (person_id, ident) do update set 
-            oppdatert = current_timestamp(3)
+            oppdatert = current_timestamp(3),
+            aktiv = excluded.aktiv
         """,
             identer
         ) {
             setParams { ident ->
                 setLong(1, personId)
                 setString(2, ident.asString)
+                setBoolean(3, ident.aktiv)
             }
         }
     }
@@ -277,7 +279,7 @@ class KelvinSakRepositoryPostgres(private val connection: DBConnection) : Kelvin
     override fun hentIdenter(saksnummer: Fagsaknummer): List<Ident> {
         return connection.queryList(
             """
-            select kelvin_person_ident.ident
+            select kelvin_person_ident.ident, kelvin_person_ident.aktiv
             from kelvin_sak
             join kelvin_person on kelvin_sak.id = kelvin_person.sak_id
             join kelvin_person_ident on kelvin_person.id = kelvin_person_ident.person_id
@@ -290,7 +292,10 @@ class KelvinSakRepositoryPostgres(private val connection: DBConnection) : Kelvin
             }
 
             setRowMapper {
-                Ident(it.getString("ident"))
+                Ident(
+                    asString = it.getString("ident"),
+                    aktiv = it.getBooleanOrNull("aktiv")
+                )
             }
         }
 

--- a/repositories/src/main/resources/flyway/V1.30__legg_til_aktiv_ident.sql
+++ b/repositories/src/main/resources/flyway/V1.30__legg_til_aktiv_ident.sql
@@ -1,0 +1,2 @@
+alter table kelvin_person_ident
+    add column aktiv boolean null;

--- a/repositories/src/test/kotlin/no/nav/aap/meldekort/kelvin/KelvinSakRepositoryPostgresTest.kt
+++ b/repositories/src/test/kotlin/no/nav/aap/meldekort/kelvin/KelvinSakRepositoryPostgresTest.kt
@@ -33,6 +33,7 @@ class KelvinSakRepositoryPostgresTest {
     val periode4 = Periode(LocalDate.of(2020, 12, 1), LocalDate.of(2020, 12, 22))
 
     private lateinit var dataSource: TestDataSource
+
     @BeforeEach
     fun setUp() {
         dataSource = TestDataSource()
@@ -146,25 +147,41 @@ class KelvinSakRepositoryPostgresTest {
             val repo = KelvinSakRepositoryPostgres(connection)
             repo.upsertSak(
                 sak1,
-                periode4,
-                listOf(fnr1, fnr3),
-                listOf(),
-                listOf(periode3),
-                listOf(periode4),
-                KelvinSakStatus.UTREDES
-            )
-            repo.upsertSak(
-                sak2,
-                periode4,
-                listOf(fnr2),
-                listOf(periode1, periode2),
+                Periode(LocalDate.of(2020, 12, 1), LocalDate.of(2020, 12, 22)),
+                listOf(fnr1.copy(aktiv = true)),
                 listOf(),
                 listOf(),
-                KelvinSakStatus.LØPENDE
+                listOf(),
+                null
             )
 
-            assertThat(repo.hentIdenter(sak1)).containsExactlyInAnyOrder(fnr1, fnr3)
-            assertThat(repo.hentIdenter(sak2)).containsExactlyInAnyOrder(fnr2)
+            assertThat(repo.hentIdenter(sak1)).containsExactlyInAnyOrder(fnr1.copy(aktiv = true))
+
+            repo.upsertSak(
+                sak2,
+                Periode(LocalDate.of(2020, 12, 1), LocalDate.of(2020, 12, 22)),
+                listOf(fnr2.copy(aktiv = true)),
+                listOf(),
+                listOf(),
+                listOf(),
+                null
+            )
+
+            repo.upsertSak(
+                sak1,
+                Periode(LocalDate.of(2020, 12, 1), LocalDate.of(2020, 12, 22)),
+                listOf(fnr1.copy(aktiv = false), fnr3.copy(aktiv = true)),
+                listOf(),
+                listOf(),
+                listOf(),
+                null
+            )
+
+            assertThat(repo.hentIdenter(sak1)).containsExactlyInAnyOrder(
+                fnr1.copy(aktiv = false),
+                fnr3.copy(aktiv = true)
+            )
+            assertThat(repo.hentIdenter(sak2)).containsExactlyInAnyOrder(fnr2.copy(aktiv = true))
         }
     }
 }


### PR DESCRIPTION
Varsel må bestilles på brukers aktive ident. Derfor må listen over identer fra behandlingsflyt utvides til å inneholde om hver enkelt ident er aktiv.