### PR TITLE
Legger til opprettetAv og fjerner hardkoding av erDigitalisert

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/meldekort/behandlingsflytApi.kt
+++ b/app/src/main/kotlin/no/nav/aap/meldekort/behandlingsflytApi.kt
@@ -79,6 +79,7 @@ fun NormalOpenAPIRoute.behandlingsflytApi(
                             fravær = null
                         )
                     },
+                    erDigitalisert = body.erDigitalisert
                 )
             }
 

--- a/app/src/test/kotlin/no/nav/aap/meldekort/AppInstance.kt
+++ b/app/src/test/kotlin/no/nav/aap/meldekort/AppInstance.kt
@@ -274,7 +274,8 @@ class AppInstance(initIdag: LocalDate = 6 januar 2025) : AutoCloseable {
     fun fyllInnTimerFraBehandlingsflyt(
         fnr: Ident,
         sakenGjelderFor: Periode,
-        periode: Periode
+        periode: Periode,
+        erDigitalisert: Boolean? = true
     ): UtfyllingReferanse {
         return dataSource.transaction { connection ->
             val kelvinMottakService = kelvinMottakService(connection, clockHolder)
@@ -291,7 +292,8 @@ class AppInstance(initIdag: LocalDate = 6 januar 2025) : AutoCloseable {
                 sakenGjelderFor = sakenGjelderFor,
                 periode = periode,
                 harDuJobbet = true,
-                aktivitetsInformasjon = dagerJobbet.map { AktivitetsInformasjon(dato = it.dato, timer = it.timerArbeidet) }
+                aktivitetsInformasjon = dagerJobbet.map { AktivitetsInformasjon(dato = it.dato, timer = it.timerArbeidet) },
+                erDigitalisert = erDigitalisert
             )
         }
     }

--- a/app/src/test/kotlin/no/nav/aap/meldekort/KelvinIntegrasjonManuellInnsendingTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/meldekort/KelvinIntegrasjonManuellInnsendingTest.kt
@@ -128,4 +128,34 @@ class KelvinIntegrasjonManuellInnsendingTest {
         val utfylling = app.hentUtfyllinger(fnr, utfyllingReferanse)
         assertEquals(utfylling?.erDigitalisert, true)
     }
+
+    @Test
+    fun `Manuelt innsent meldekort kan settes til ikke-digitalisert`() {
+        val idag = LocalDate.of(2025, 12, 1)
+        app.idag = idag
+
+        val fnr = fødselsnummerGenerator.next()
+        val rettighetsperiode = Periode(17 november 2025, idag.plusWeeks(51))
+        app.kelvinSak(
+            fnr,
+            rettighetsperiode = rettighetsperiode,
+            opplysningsbehov = listOf(Periode(17 november 2025, idag.plusWeeks(51)))
+        )
+
+        app.fyllInnTimer(
+            fnr,
+            opplysningerOm = Periode(17 november 2025, 30 november 2025),
+            sakStart = rettighetsperiode.fom
+        )
+
+        app.idag = LocalDate.of(2025, 12, 29)
+
+        val utfyllingReferanse = app.fyllInnTimerFraBehandlingsflyt(
+            fnr, rettighetsperiode, Periode(15 desember 2025, 28 desember 2025),
+            erDigitalisert = false
+        )
+
+        val utfylling = app.hentUtfyllinger(fnr, utfyllingReferanse)
+        assertEquals(false, utfylling?.erDigitalisert)
+    }
 }

--- a/kontrakt/src/main/kotlin/no/nav/aap/meldekort/kontrakt/sak/Sak.kt
+++ b/kontrakt/src/main/kotlin/no/nav/aap/meldekort/kontrakt/sak/Sak.kt
@@ -36,7 +36,9 @@ public data class BehandslingsflytUtfyllingRequest(
     val periode: Periode,
     val harDuJobbet: Boolean,
     val dager: List<TimerArbeidetDto>,
-    val sakenGjelderFor: Periode
+    val sakenGjelderFor: Periode,
+    val erDigitalisert: Boolean? = true, // bakoverkompatibel
+    val opprettetAv: String? = null, // bakoverkompatibel
 )
 
 public data class TimerArbeidetDto(

--- a/meldekortdomene/src/main/kotlin/no/nav/aap/kelvin/KelvinMottakService.kt
+++ b/meldekortdomene/src/main/kotlin/no/nav/aap/kelvin/KelvinMottakService.kt
@@ -59,7 +59,8 @@ class KelvinMottakService(
         sakenGjelderFor: Periode,
         periode: Periode,
         harDuJobbet: Boolean,
-        aktivitetsInformasjon: List<no.nav.aap.utfylling.AktivitetsInformasjon>
+        aktivitetsInformasjon: List<no.nav.aap.utfylling.AktivitetsInformasjon>,
+        erDigitalisert: Boolean? = true
     ): UtfyllingReferanse {
         val sak = kelvinSakRepository.hentSak(ident, sakenGjelderFor.fom)
             ?: throw IllegalStateException("finner ikke sak")
@@ -90,7 +91,7 @@ class KelvinMottakService(
             ),
             opprettet = Instant.now(clock),
             sistEndret = Instant.now(clock),
-            erDigitalisert = true
+            erDigitalisert = erDigitalisert
         )
 
         utfyllingRepository.lagreUtfylling(utfylling)


### PR DESCRIPTION
- Nå som `/timer` ikke kun brukes av digitaliser meldekort, sendes nå denne verdien som parameter videre ned slik at hardkoding kan fjernes.
- Legger til `opprettetAv` som potensielt kan brukes for å vise hvem som la inn meldekortet. 