### PR TITLE
Endrer fra NAV til Nav i journalpost-tittel

### DIFF
--- a/meldekortdomene/src/main/kotlin/no/nav/aap/journalføring/JournalføringService.kt
+++ b/meldekortdomene/src/main/kotlin/no/nav/aap/journalføring/JournalføringService.kt
@@ -101,7 +101,7 @@ class JournalføringService(
         val uke2 = utfylling.periode.tom.get(uke)
         val fra = utfylling.periode.fom.format(dateFormatter)
         val til = utfylling.periode.tom.format(dateFormatter)
-        val tittelsuffix = "for uke $uke1 - $uke2 ($fra - $til) elektronisk mottatt av NAV"
+        val tittelsuffix = "for uke $uke1 - $uke2 ($fra - $til) elektronisk mottatt av Nav"
         val tittel = when (utfylling.flyt) {
             AAP_FLYT, AAP_FLYT_V2 ->
                 "Meldekort $tittelsuffix"


### PR DESCRIPTION
Iht nye retningslinjer skrives det nå `Nav` og ikke `NAV`. Endrer tittel for journalpost. 