### PR TITLE
AAP-BAU Optimaliser oppdatering av planlagte varsler i databasen

### DIFF
--- a/meldekortdomene/src/main/kotlin/no/nav/aap/varsel/VarselRepository.kt
+++ b/meldekortdomene/src/main/kotlin/no/nav/aap/varsel/VarselRepository.kt
@@ -7,7 +7,6 @@ import java.time.Clock
 interface VarselRepository: Repository {
     fun hentVarsler(saksnummer: Fagsaknummer): List<Varsel>
     fun upsert(varsel: Varsel)
-    fun slettVarsel(varselId: VarselId)
-    fun slettPlanlagteVarsler(saksnummer: Fagsaknummer, typeVarselOm: TypeVarselOm)
+    fun slettPlanlagtVarsel(varselId: VarselId)
     fun hentVarslerForUtsending(clock: Clock) : List<Varsel>
 }

--- a/meldekortdomene/src/main/kotlin/no/nav/aap/varsel/VarselService.kt
+++ b/meldekortdomene/src/main/kotlin/no/nav/aap/varsel/VarselService.kt
@@ -55,10 +55,9 @@ class VarselService(
             log.warn("Meldevindu i meldeperioder samsvarer ikke med meldeplikt-perioder fra Kelvin. Saksnummer: ${saksnummer.asString}")
         }
 
-        varselRepository.slettPlanlagteVarsler(saksnummer, TypeVarselOm.MELDEPLIKTPERIODE)
         val sendteVarsler = varselRepository.hentVarsler(saksnummer).filter { it.status == VarselStatus.SENDT }
         inaktiverVarslerForFjernetMeldeplikt(meldeperioderMedMeldeplikt, sendteVarsler)
-        lagreFremtidigeVarsler(saksnummer, meldeperioderMedMeldeplikt, sendteVarsler)
+        oppdaterFremtidigeVarsler(saksnummer, meldeperioderMedMeldeplikt, sendteVarsler)
     }
 
     private fun inaktiverVarslerForFjernetMeldeplikt(
@@ -72,7 +71,7 @@ class VarselService(
             }
     }
 
-    private fun lagreFremtidigeVarsler(
+    private fun oppdaterFremtidigeVarsler(
         saksnummer: Fagsaknummer,
         meldeperioder: List<Meldeperiode>,
         sendteVarsler: List<Varsel>
@@ -89,12 +88,20 @@ class VarselService(
 
                 (erIMeldevinduet && !harSendtVarselForPerioden) || meldevinduIFremtiden
             }
-        fremtidigeMeldeperioder
+        val nyePlanlagteVarsler = fremtidigeMeldeperioder
             .filterNot { harUtfylling(it.meldeperioden, utfyllinger) }
             .map { lagVarsel(saksnummer, it, TypeVarselOm.MELDEPLIKTPERIODE) }
-            .forEach { varsel ->
-                varselRepository.upsert(varsel)
-            }
+
+        val eksisterendePlanlagte = varselRepository.hentVarsler(saksnummer)
+            .filter { it.status == VarselStatus.PLANLAGT && it.typeVarselOm == TypeVarselOm.MELDEPLIKTPERIODE }
+
+        eksisterendePlanlagte
+            .filterNot { gammelt -> nyePlanlagteVarsler.any { it.forPeriode == gammelt.forPeriode } }
+            .forEach { varselRepository.slettPlanlagtVarsel(it.varselId) }
+
+        nyePlanlagteVarsler
+            .filterNot { nytt -> eksisterendePlanlagte.any { it.forPeriode == nytt.forPeriode } }
+            .forEach { varselRepository.upsert(it) }
     }
 
     private fun harUtfylling(forPeriode: Periode, utfyllinger: List<Utfylling>): Boolean {
@@ -151,7 +158,7 @@ class VarselService(
                 "Avbryter sending og sletter planlagt varsel som allerede har en utfylling." +
                         "Saksnummer: ${varsel.saksnummer.asString}, varselId: ${varsel.varselId}, forPeriode: ${varsel.forPeriode}, sendingstidspunkt: ${varsel.sendingstidspunkt}"
             )
-            varselRepository.slettVarsel(varsel.varselId)
+            varselRepository.slettPlanlagtVarsel(varsel.varselId)
             return
         }
 

--- a/meldekortdomene/src/main/kotlin/no/nav/aap/varsel/VarselService.kt
+++ b/meldekortdomene/src/main/kotlin/no/nav/aap/varsel/VarselService.kt
@@ -96,11 +96,11 @@ class VarselService(
             .filter { it.status == VarselStatus.PLANLAGT && it.typeVarselOm == TypeVarselOm.MELDEPLIKTPERIODE }
 
         eksisterendePlanlagte
-            .filterNot { gammelt -> nyePlanlagteVarsler.any { it.forPeriode == gammelt.forPeriode } }
+            .filter { gammelt -> nyePlanlagteVarsler.none { it.forPeriode == gammelt.forPeriode } }
             .forEach { varselRepository.slettPlanlagtVarsel(it.varselId) }
 
         nyePlanlagteVarsler
-            .filterNot { nytt -> eksisterendePlanlagte.any { it.forPeriode == nytt.forPeriode } }
+            .filter { nytt -> eksisterendePlanlagte.none { it.forPeriode == nytt.forPeriode } }
             .forEach { varselRepository.upsert(it) }
     }
 

--- a/repositories/src/main/kotlin/no/nav/aap/varsel/VarselRepositoryPostgres.kt
+++ b/repositories/src/main/kotlin/no/nav/aap/varsel/VarselRepositoryPostgres.kt
@@ -57,38 +57,18 @@ class VarselRepositoryPostgres(private val connection: DBConnection) : VarselRep
         }
     }
 
-    override fun slettVarsel(varselId: VarselId) {
+    override fun slettPlanlagtVarsel(varselId: VarselId) {
         connection.execute(
             """
             delete from varsel
-            where varsel_id = ?
+            where varsel_id = ? and status = 'PLANLAGT'
             """
         ) {
             setParams {
                 setUUID(1, varselId.id)
             }
             setResultValidator {
-                require(it == 1)
-            }
-        }
-    }
-
-    override fun slettPlanlagteVarsler(
-        saksnummer: Fagsaknummer,
-        typeVarselOm: TypeVarselOm
-    ) {
-        connection.execute(
-            """
-            delete from varsel
-            where saksnummer = ?
-             and status = ?
-            and type_varsel_om = ?
-            """
-        ) {
-            setParams {
-                setString(1, saksnummer.asString)
-                setEnumName(2, VarselStatus.PLANLAGT)
-                setEnumName(3, typeVarselOm)
+                require(it in 0..1)
             }
         }
     }

--- a/repositories/src/test/kotlin/no/nav/aap/meldekort/varsel/VarselRepositoryPostgresTest.kt
+++ b/repositories/src/test/kotlin/no/nav/aap/meldekort/varsel/VarselRepositoryPostgresTest.kt
@@ -28,6 +28,7 @@ import java.time.Clock
 class VarselRepositoryPostgresTest {
 
     private lateinit var dataSource: TestDataSource
+
     @BeforeEach
     fun setUp() {
         dataSource = TestDataSource()
@@ -38,7 +39,7 @@ class VarselRepositoryPostgresTest {
         dataSource.close()
         dataSource = TestDataSource()
     }
-    
+
     @Test
     fun `oppretter, henter, oppdaterer og sletter varsler`() {
         val saksnummer = Fagsaknummer("123")
@@ -63,6 +64,11 @@ class VarselRepositoryPostgresTest {
 
             varselRepo.upsert(varsel)
 
+            val annenSak = Fagsaknummer("321")
+            opprettSak(sakRepo, annenSak)
+            val urelatertVarsel = byggVarsel(saksnummer = annenSak)
+            varselRepo.upsert(urelatertVarsel)
+
             varselRepo.hentVarsler(saksnummer).also { varsler ->
                 assertThat(varsler).containsExactly(varsel)
             }
@@ -85,66 +91,19 @@ class VarselRepositoryPostgresTest {
                 assertThat(varsler).containsExactly(oppdatertVarsel)
             }
 
-            varselRepo.slettVarsel(varsel.varselId)
+            varselRepo.slettPlanlagtVarsel(varsel.varselId)
+            varselRepo.hentVarsler(saksnummer).also { varsler ->
+                assertThat(varsler).containsExactly(oppdatertVarsel) // kun planlagt varsel kan slettes
+            }
 
+            varselRepo.upsert(oppdatertVarsel.copy(status = VarselStatus.PLANLAGT))
+            varselRepo.slettPlanlagtVarsel(varsel.varselId)
             varselRepo.hentVarsler(saksnummer).also { varsler ->
                 assertThat(varsler).isEmpty()
             }
-        }
-    }
 
-    @Test
-    fun `sletter planlagte varsler`() {
-        val saksnummer = Fagsaknummer("1234")
-
-        dataSource.transaction { connection ->
-            val sakRepo = KelvinSakRepositoryPostgres(connection)
-            val varselRepo = VarselRepositoryPostgres(connection)
-
-            opprettSak(sakRepo, saksnummer)
-            val planlagtValselMeldepliktperiode = byggVarsel(
-                saksnummer = saksnummer,
-                status = VarselStatus.PLANLAGT,
-                typeVarselOm = TypeVarselOm.MELDEPLIKTPERIODE
-            )
-            val planlagtValselOpplysningsbehov = byggVarsel(
-                saksnummer = saksnummer,
-                status = VarselStatus.PLANLAGT,
-                typeVarselOm = TypeVarselOm.OPPLYSNINGSBEHOV
-            )
-            val sendtValselMeldepliktperiode = byggVarsel(
-                saksnummer = saksnummer,
-                status = VarselStatus.SENDT,
-                typeVarselOm = TypeVarselOm.MELDEPLIKTPERIODE
-            )
-            val inaktivertValselMeldepliktperiode = byggVarsel(
-                saksnummer = saksnummer,
-                status = VarselStatus.INAKTIVERT,
-                typeVarselOm = TypeVarselOm.MELDEPLIKTPERIODE
-            )
-
-            varselRepo.upsert(planlagtValselMeldepliktperiode)
-            varselRepo.upsert(planlagtValselOpplysningsbehov)
-            varselRepo.upsert(sendtValselMeldepliktperiode)
-            varselRepo.upsert(inaktivertValselMeldepliktperiode)
-
-            varselRepo.hentVarsler(saksnummer).also { varsler ->
-                assertThat(varsler).containsExactlyInAnyOrder(
-                    planlagtValselMeldepliktperiode,
-                    planlagtValselOpplysningsbehov,
-                    sendtValselMeldepliktperiode,
-                    inaktivertValselMeldepliktperiode
-                )
-            }
-
-            varselRepo.slettPlanlagteVarsler(saksnummer, TypeVarselOm.MELDEPLIKTPERIODE)
-
-            varselRepo.hentVarsler(saksnummer).also { varsler ->
-                assertThat(varsler).containsExactlyInAnyOrder(
-                    planlagtValselOpplysningsbehov,
-                    sendtValselMeldepliktperiode,
-                    inaktivertValselMeldepliktperiode
-                )
+            varselRepo.hentVarsler(urelatertVarsel.saksnummer).also { varsler ->
+                assertThat(varsler).containsExactly(urelatertVarsel)
             }
         }
     }
@@ -269,7 +228,7 @@ class VarselRepositoryPostgresTest {
                         varselRepo.hentVarsler(saksnummer3) +
                         varselRepo.hentVarsler(saksnummer4)
             ).containsExactlyInAnyOrder(
-                * alleVarsler.toTypedArray()
+                *alleVarsler.toTypedArray()
             )
 
             varselRepo.hentVarslerForUtsending(clock).also {


### PR DESCRIPTION
Bakgrunn for endringen er tregheter i query for sletting av varsler. Ved oppdatering på meldeperioder for en sak ble alle planlagte varsler slettet og deretter ble nye satt inn. Endrer til å kun slette de som ikke gjelder lenger, og insert på de som er nye (snittet mellom gamle og nye forblir urørt).

Endringene skal ikke medføre endring i funksjonalitet.