### PR TITLE
chore: add systemkatalog.nav.no/system label to nais manifest

### DIFF
--- a/.nais/dev-gcp.yml
+++ b/.nais/dev-gcp.yml
@@ -7,7 +7,7 @@ metadata:
     labels:
         team: aap
         sub: meldekort-backend
-        systemkatalog.nav.no/system: TE-496
+        systemkatalog.nav.no/system: SK-268
     annotations:
         texas.nais.io/enabled: "true"
 

--- a/.nais/dev-gcp.yml
+++ b/.nais/dev-gcp.yml
@@ -7,6 +7,7 @@ metadata:
     labels:
         team: aap
         sub: meldekort-backend
+        systemkatalog.nav.no/system: TE-496
     annotations:
         texas.nais.io/enabled: "true"
 

--- a/.nais/prod-gcp.yml
+++ b/.nais/prod-gcp.yml
@@ -7,7 +7,7 @@ metadata:
     labels:
         team: aap
         sub: meldekort-backend
-        systemkatalog.nav.no/system: TE-496
+        systemkatalog.nav.no/system: SK-268
     annotations:
         texas.nais.io/enabled: "true"
 

--- a/.nais/prod-gcp.yml
+++ b/.nais/prod-gcp.yml
@@ -7,6 +7,7 @@ metadata:
     labels:
         team: aap
         sub: meldekort-backend
+        systemkatalog.nav.no/system: TE-496
     annotations:
         texas.nais.io/enabled: "true"
 


### PR DESCRIPTION
Adds the `systemkatalog.nav.no/system: TE-496` label to the nais Application manifest so this app is registered in systemkatalog.nav.no.